### PR TITLE
feat: Add support for saving meals to the planner

### DIFF
--- a/components/molecules/DayContainer.tsx
+++ b/components/molecules/DayContainer.tsx
@@ -1,18 +1,36 @@
+import { useRouter } from 'next/router';
+
 import Button from '../atoms/Button';
 
 type DayContainerProps = {
-  dayName: string
+  dayName: string,
 };
 
-const DayContainer = ({ dayName }: DayContainerProps) => (
-  <section>
-    <h3 className="bigger text-align-center">{dayName}</h3>
+const DayContainer = ({ dayName }: DayContainerProps) => {
+  const router = useRouter();
 
-    <Button
-      buttonType="button"
-      buttonName="add meal"
-    />
-  </section>
-);
+  const handleAddMeal = () => {
+    router.push(
+      {
+        pathname: '/planner/add',
+        query: { day: dayName },
+      },
+      '/planner/add',
+    );
+  };
+
+  return (
+    <section>
+      <h3 className="bigger text-align-center">{dayName}</h3>
+
+      <Button
+        buttonType="button"
+        buttonName="add meal"
+        modifier="--link"
+        onClick={handleAddMeal}
+      />
+    </section>
+  );
+};
 
 export default DayContainer;

--- a/components/molecules/DayContainer.tsx
+++ b/components/molecules/DayContainer.tsx
@@ -1,27 +1,58 @@
+import { useEffect, useState } from 'react';
 import { useRouter } from 'next/router';
+
+import { getRecipeById, getMeals } from '../../services/dbService';
 
 import Button from '../atoms/Button';
 
 type DayContainerProps = {
-  dayName: string,
+  dayId: number,
+  dayName: string
 };
 
-const DayContainer = ({ dayName }: DayContainerProps) => {
+const DayContainer = ({ dayName, dayId }: DayContainerProps) => {
+  const dayIdAsString = dayId.toString();
+  const [meals, setMeals] = useState<{ id: string, recipeName: string }[]>();
   const router = useRouter();
 
   const handleAddMeal = () => {
     router.push(
       {
         pathname: '/planner/add',
-        query: { day: dayName },
+        query: { id: dayId, day: dayName },
       },
       '/planner/add',
     );
   };
 
+  useEffect(() => {
+    const getAndSetData = async () => {
+      try {
+        const dayMeals = await getMeals(dayIdAsString);
+        const newMealsState = await Promise.all(dayMeals.map(async (meal) => {
+          const recipe = await getRecipeById(meal.recipeId);
+
+          return { id: meal.id, recipeName: recipe.name };
+        }));
+
+        setMeals(newMealsState);
+      } catch (err) {
+        setMeals([]);
+      }
+    };
+
+    getAndSetData();
+  }, [dayIdAsString]);
+
   return (
     <section>
       <h3 className="bigger text-align-center">{dayName}</h3>
+
+      <ul>
+        {meals && meals.map((meal: { id: string, recipeName: string }) => (
+          <li key={meal.id}>{meal.recipeName}</li>
+        ))}
+      </ul>
 
       <Button
         buttonType="button"

--- a/components/molecules/DayContainer.tsx
+++ b/components/molecules/DayContainer.tsx
@@ -1,18 +1,18 @@
+/* eslint-disable jsx-a11y/anchor-is-valid */
 import { useEffect, useState } from 'react';
+import Link from 'next/link';
 import { useRouter } from 'next/router';
-
-import { getRecipeById, getMeals } from '../../services/dbService';
 
 import Button from '../atoms/Button';
 
 type DayContainerProps = {
   dayId: number,
-  dayName: string
+  dayName: string,
+  dayMeals: { id: string, recipeId: string, recipeName: string }[] | undefined
 };
 
-const DayContainer = ({ dayName, dayId }: DayContainerProps) => {
-  const dayIdAsString = dayId.toString();
-  const [meals, setMeals] = useState<{ id: string, recipeName: string }[]>();
+const DayContainer = ({ dayName, dayId, dayMeals }: DayContainerProps) => {
+  const [meals, setMeals] = useState<{ id: string, recipeId: string, recipeName: string }[]>();
   const router = useRouter();
 
   const handleAddMeal = () => {
@@ -26,33 +26,20 @@ const DayContainer = ({ dayName, dayId }: DayContainerProps) => {
   };
 
   useEffect(() => {
-    const getAndSetData = async () => {
-      try {
-        const dayMeals = await getMeals(dayIdAsString);
-        const newMealsState = await Promise.all(dayMeals.map(async (meal) => {
-          const recipe = await getRecipeById(meal.recipeId);
-
-          return { id: meal.id, recipeName: recipe.name };
-        }));
-
-        setMeals(newMealsState);
-      } catch (err) {
-        setMeals([]);
-      }
-    };
-
-    getAndSetData();
-  }, [dayIdAsString]);
+    setMeals(dayMeals);
+  }, [dayMeals]);
 
   return (
     <section>
       <h3 className="bigger text-align-center">{dayName}</h3>
 
-      <ul>
-        {meals && meals.map((meal: { id: string, recipeName: string }) => (
-          <li key={meal.id}>{meal.recipeName}</li>
-        ))}
-      </ul>
+      {meals?.map((meal: { id: string, recipeId: string, recipeName: string }) => (
+        <div key={meal.id}>
+          <Link href={`/recipes/${meal.recipeId}`}>
+            <a>{meal.recipeName}</a>
+          </Link>
+        </div>
+      ))}
 
       <Button
         buttonType="button"

--- a/components/molecules/MealsList.tsx
+++ b/components/molecules/MealsList.tsx
@@ -9,10 +9,11 @@ import IconButton from '../atoms/IconButton';
 
 type MealsListProps = {
   dayId: string | string[] | undefined,
+  categoryName: string,
   meals: IRecipe[],
 };
 
-const MealsList = ({ dayId, meals }: MealsListProps) => {
+const MealsList = ({ dayId, categoryName, meals }: MealsListProps) => {
   const router = useRouter();
 
   const handleClick = async (id: string | string[] | undefined, mealId: string) => {
@@ -22,7 +23,9 @@ const MealsList = ({ dayId, meals }: MealsListProps) => {
   };
 
   return (
-    <>
+    <section>
+      <h2 className="section">{categoryName}</h2>
+
       {meals.map((meal) => (
         <div key={meal.id} className="grid-end-button">
           <Link href={`/recipes/${meal.id}`}>
@@ -35,7 +38,7 @@ const MealsList = ({ dayId, meals }: MealsListProps) => {
           />
         </div>
       ))}
-    </>
+    </section>
   );
 };
 

--- a/components/molecules/MealsList.tsx
+++ b/components/molecules/MealsList.tsx
@@ -1,0 +1,42 @@
+/* eslint-disable jsx-a11y/anchor-is-valid */
+import Link from 'next/link';
+import { useRouter } from 'next/router';
+
+import IRecipe from '../../interfaces/IRecipe';
+import { addMealToPlan } from '../../services/dbService';
+
+import IconButton from '../atoms/IconButton';
+
+type MealsListProps = {
+  dayId: string | string[] | undefined,
+  meals: IRecipe[],
+};
+
+const MealsList = ({ dayId, meals }: MealsListProps) => {
+  const router = useRouter();
+
+  const handleClick = async (id: string | string[] | undefined, mealId: string) => {
+    await addMealToPlan(id, mealId);
+
+    router.push('/planner');
+  };
+
+  return (
+    <>
+      {meals.map((meal) => (
+        <div key={meal.id} className="grid-end-button">
+          <Link href={`/recipes/${meal.id}`}>
+            <a>{meal.name}</a>
+          </Link>
+
+          <IconButton
+            plus
+            onClick={() => handleClick(dayId, meal.id)}
+          />
+        </div>
+      ))}
+    </>
+  );
+};
+
+export default MealsList;

--- a/components/organisms/Planner.tsx
+++ b/components/organisms/Planner.tsx
@@ -11,7 +11,9 @@ const Planner = ({ daysOfTheWeek, shoppingDay }: PlannerProps) => {
   const newShoppingWeekStart = daysOfTheWeek.slice(indexOfShoppingDay);
   const newShoppingWeekEnd = daysOfTheWeek.slice(0, indexOfShoppingDay + 1);
 
-  const shoppingWeek = [...newShoppingWeekStart, ...newShoppingWeekEnd];
+  const shoppingWeek = [...newShoppingWeekStart, ...newShoppingWeekEnd].map((day, idx) => (
+    { id: idx, name: day }
+  ));
 
   return (
     <article>
@@ -23,8 +25,8 @@ const Planner = ({ daysOfTheWeek, shoppingDay }: PlannerProps) => {
 
       {shoppingWeek.map((day) => (
         <DayContainer
-          key={day}
-          dayName={day}
+          key={day.id}
+          dayName={day.name}
         />
       ))}
     </article>

--- a/components/organisms/Planner.tsx
+++ b/components/organisms/Planner.tsx
@@ -2,10 +2,13 @@ import DayContainer from '../molecules/DayContainer';
 
 type PlannerProps = {
   daysOfTheWeek: string[],
-  shoppingDay: string
+  shoppingDay: string,
+  plannedMeals: {
+    [key: string | number]: { id: string, recipeId: string, recipeName: string }[]
+  } | undefined
 };
 
-const Planner = ({ daysOfTheWeek, shoppingDay }: PlannerProps) => {
+const Planner = ({ daysOfTheWeek, shoppingDay, plannedMeals }: PlannerProps) => {
   const indexOfShoppingDay = daysOfTheWeek.indexOf(shoppingDay);
 
   const newShoppingWeekStart = daysOfTheWeek.slice(indexOfShoppingDay);
@@ -23,13 +26,18 @@ const Planner = ({ daysOfTheWeek, shoppingDay }: PlannerProps) => {
         {shoppingDay}
       </h2>
 
-      {shoppingWeek.map((day) => (
-        <DayContainer
-          key={day.id}
-          dayId={day.id}
-          dayName={day.name}
-        />
-      ))}
+      {shoppingWeek.map((day, idx) => {
+        const idxString = idx.toString();
+
+        return (
+          <DayContainer
+            key={day.id}
+            dayId={day.id}
+            dayName={day.name}
+            dayMeals={plannedMeals ? plannedMeals[idxString] : []}
+          />
+        );
+      })}
     </article>
   );
 };

--- a/components/organisms/Planner.tsx
+++ b/components/organisms/Planner.tsx
@@ -26,6 +26,7 @@ const Planner = ({ daysOfTheWeek, shoppingDay }: PlannerProps) => {
       {shoppingWeek.map((day) => (
         <DayContainer
           key={day.id}
+          dayId={day.id}
           dayName={day.name}
         />
       ))}

--- a/interfaces/IMealPlan.ts
+++ b/interfaces/IMealPlan.ts
@@ -1,0 +1,6 @@
+export default interface IMealPlan {
+  id: number,
+  meals: {
+    [key: string | number]: { recipeId: string }[] | [],
+  }
+}

--- a/interfaces/IMealPlan.ts
+++ b/interfaces/IMealPlan.ts
@@ -1,6 +1,6 @@
 export default interface IMealPlan {
   id: number,
   meals: {
-    [key: string | number]: { recipeId: string }[] | [],
+    [key: string | number]: { id: string, recipeId: string }[],
   }
 }

--- a/interfaces/IRecipeBook.ts
+++ b/interfaces/IRecipeBook.ts
@@ -1,0 +1,7 @@
+import IRecipe from './IRecipe';
+
+export default interface RecipeBook {
+  breakfast: IRecipe[],
+  lunch: IRecipe[],
+  dinner: IRecipe[],
+}

--- a/pages/planner/add.tsx
+++ b/pages/planner/add.tsx
@@ -1,0 +1,21 @@
+import { NextPage } from 'next';
+import { useRouter } from 'next/router';
+
+import Layout from '../../components/organisms/Layout';
+
+const AddMealPage: NextPage = () => {
+  const router = useRouter();
+  const { day } = router.query;
+
+  return (
+    <Layout>
+      <h1 className="title text-align-center">
+        Add Meal to
+        {' '}
+        {day}
+      </h1>
+    </Layout>
+  );
+};
+
+export default AddMealPage;

--- a/pages/planner/add.tsx
+++ b/pages/planner/add.tsx
@@ -1,11 +1,42 @@
+import { useState, useEffect } from 'react';
 import { NextPage } from 'next';
 import { useRouter } from 'next/router';
 
+import IRecipe from '../../interfaces/IRecipe';
+import { getAllRecipes } from '../../services/dbService';
+
+import MealsList from '../../components/molecules/MealsList';
+
 import Layout from '../../components/organisms/Layout';
 
+interface MealBook {
+  meals: IRecipe[],
+}
+
 const AddMealPage: NextPage = () => {
+  const [meals, setMeals] = useState<MealBook>();
   const router = useRouter();
-  const { day } = router.query;
+  const { id, day } = router.query;
+
+  useEffect(() => {
+    const getAndSetData = async () => {
+      try {
+        const allMeals = await getAllRecipes();
+
+        const newMealsState = {
+          meals: [...allMeals],
+        };
+
+        setMeals(newMealsState);
+      } catch (err) {
+        setMeals({
+          meals: [],
+        });
+      }
+    };
+
+    getAndSetData();
+  });
 
   return (
     <Layout>
@@ -14,6 +45,13 @@ const AddMealPage: NextPage = () => {
         {' '}
         {day}
       </h1>
+
+      {meals && (
+        <MealsList
+          meals={meals.meals}
+          dayId={id}
+        />
+      )}
     </Layout>
   );
 };

--- a/pages/planner/add.tsx
+++ b/pages/planner/add.tsx
@@ -3,34 +3,39 @@ import { NextPage } from 'next';
 import { useRouter } from 'next/router';
 
 import IRecipe from '../../interfaces/IRecipe';
+import IRecipeBook from '../../interfaces/IRecipeBook';
 import { getAllRecipes } from '../../services/dbService';
 
 import MealsList from '../../components/molecules/MealsList';
 
 import Layout from '../../components/organisms/Layout';
 
-interface MealBook {
-  meals: IRecipe[],
-}
-
 const AddMealPage: NextPage = () => {
-  const [meals, setMeals] = useState<MealBook>();
+  const [meals, setMeals] = useState<IRecipeBook>();
   const router = useRouter();
   const { id, day } = router.query;
 
   useEffect(() => {
     const getAndSetData = async () => {
       try {
-        const allMeals = await getAllRecipes();
+        const allRecipes = await getAllRecipes();
+
+        const breakfastRecipes = allRecipes.filter((recipe: IRecipe) => recipe.category === 'Breakfast');
+        const lunchRecipes = allRecipes.filter((recipe: IRecipe) => recipe.category === 'Lunch');
+        const dinnerRecipes = allRecipes.filter((recipe: IRecipe) => recipe.category === 'Dinner');
 
         const newMealsState = {
-          meals: [...allMeals],
+          breakfast: [...breakfastRecipes],
+          lunch: [...lunchRecipes],
+          dinner: [...dinnerRecipes],
         };
 
         setMeals(newMealsState);
       } catch (err) {
         setMeals({
-          meals: [],
+          breakfast: [],
+          lunch: [],
+          dinner: [],
         });
       }
     };
@@ -47,10 +52,25 @@ const AddMealPage: NextPage = () => {
       </h1>
 
       {meals && (
-        <MealsList
-          meals={meals.meals}
-          dayId={id}
-        />
+        <>
+          <MealsList
+            dayId={id}
+            categoryName="Breakfast"
+            meals={meals.breakfast}
+          />
+
+          <MealsList
+            dayId={id}
+            categoryName="Lunch"
+            meals={meals.lunch}
+          />
+
+          <MealsList
+            dayId={id}
+            categoryName="Dinner"
+            meals={meals.dinner}
+          />
+        </>
       )}
     </Layout>
   );

--- a/pages/planner/index.tsx
+++ b/pages/planner/index.tsx
@@ -1,11 +1,13 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { NextPage } from 'next';
 
 import Layout from '../../components/organisms/Layout';
 import Planner from '../../components/organisms/Planner';
 
+import { addShoppingDay, getShoppingDay } from '../../services/dbService';
+
 const PlannerPage: NextPage = () => {
-  const [shoppingDay, setShoppingDay] = useState(null);
+  const [shoppingDay, setShoppingDay] = useState('');
 
   const DAYS_OF_THE_WEEK = [
     'Sunday',
@@ -18,8 +20,20 @@ const PlannerPage: NextPage = () => {
   ];
 
   const handleSelect = (e: { target: any }) => {
+    addShoppingDay(e.target.value);
+
     setShoppingDay(e.target.value);
   };
+
+  useEffect(() => {
+    const getAndSetData = async () => {
+      const savedShoppingDay = await getShoppingDay();
+
+      setShoppingDay(savedShoppingDay);
+    };
+
+    getAndSetData();
+  }, [shoppingDay]);
 
   return (
     <Layout>
@@ -32,10 +46,13 @@ const PlannerPage: NextPage = () => {
           <select
             name="shoppingDay"
             onChange={handleSelect}
+            value={shoppingDay}
           >
             <option aria-label="none" value="" />
             {DAYS_OF_THE_WEEK.map((day) => (
-              <option key={day} value={day}>{day}</option>
+              <option key={day} value={day}>
+                {day}
+              </option>
             ))}
           </select>
         </label>

--- a/pages/planner/index.tsx
+++ b/pages/planner/index.tsx
@@ -4,7 +4,7 @@ import { NextPage } from 'next';
 import Layout from '../../components/organisms/Layout';
 import Planner from '../../components/organisms/Planner';
 
-import { addShoppingDay, getShoppingDay } from '../../services/dbService';
+import { selectShoppingDay, getShoppingDay, createMealPlan } from '../../services/dbService';
 
 const PlannerPage: NextPage = () => {
   const [shoppingDay, setShoppingDay] = useState('');
@@ -20,7 +20,8 @@ const PlannerPage: NextPage = () => {
   ];
 
   const handleSelect = (e: { target: any }) => {
-    addShoppingDay(e.target.value);
+    selectShoppingDay(e.target.value);
+    createMealPlan();
 
     setShoppingDay(e.target.value);
   };

--- a/pages/planner/index.tsx
+++ b/pages/planner/index.tsx
@@ -4,10 +4,20 @@ import { NextPage } from 'next';
 import Layout from '../../components/organisms/Layout';
 import Planner from '../../components/organisms/Planner';
 
-import { selectShoppingDay, getShoppingDay, createMealPlan } from '../../services/dbService';
+import {
+  selectShoppingDay,
+  getShoppingDay,
+  createMealPlan,
+  getAllPlannedMeals,
+} from '../../services/dbService';
+
+type MealPlan = {
+  [key: number]: { id: string, recipeId: string, recipeName: string }[]
+};
 
 const PlannerPage: NextPage = () => {
   const [shoppingDay, setShoppingDay] = useState('');
+  const [plannedMeals, setPlannedMeals] = useState<MealPlan>();
 
   const DAYS_OF_THE_WEEK = [
     'Sunday',
@@ -27,14 +37,34 @@ const PlannerPage: NextPage = () => {
   };
 
   useEffect(() => {
-    const getAndSetData = async () => {
+    const getAndSetShoppingDay = async () => {
       const savedShoppingDay = await getShoppingDay();
 
       setShoppingDay(savedShoppingDay);
     };
 
-    getAndSetData();
-  }, [shoppingDay]);
+    const getAndSetPlannedMeals = async () => {
+      try {
+        const currentPlannedMeals = await getAllPlannedMeals();
+
+        setPlannedMeals(currentPlannedMeals);
+      } catch (err) {
+        setPlannedMeals({
+          0: [],
+          1: [],
+          2: [],
+          3: [],
+          4: [],
+          5: [],
+          6: [],
+          7: [],
+        });
+      }
+    };
+
+    getAndSetShoppingDay();
+    getAndSetPlannedMeals();
+  }, [shoppingDay, plannedMeals]);
 
   return (
     <Layout>
@@ -63,6 +93,7 @@ const PlannerPage: NextPage = () => {
         <Planner
           daysOfTheWeek={DAYS_OF_THE_WEEK}
           shoppingDay={shoppingDay}
+          plannedMeals={plannedMeals}
         />
       )}
     </Layout>

--- a/pages/recipes/index.tsx
+++ b/pages/recipes/index.tsx
@@ -1,20 +1,16 @@
 import { useEffect, useState } from 'react';
 import { NextPage } from 'next';
 import Link from 'next/link';
-import { getAllRecipes } from '../../services/dbService';
 
 import IRecipe from '../../interfaces/IRecipe';
+import IRecipeBook from '../../interfaces/IRecipeBook';
+import { getAllRecipes } from '../../services/dbService';
+
 import Layout from '../../components/organisms/Layout';
 import RecipeBookCategory from '../../components/organisms/RecipeBookCategory';
 
-interface RecipeBook {
-  breakfast: IRecipe[],
-  lunch: IRecipe[],
-  dinner: IRecipe[],
-}
-
 const RecipesPage: NextPage = () => {
-  const [recipes, setRecipes] = useState<RecipeBook>();
+  const [recipes, setRecipes] = useState<IRecipeBook>();
 
   useEffect(() => {
     const getAndSetData = async () => {

--- a/services/dbService.ts
+++ b/services/dbService.ts
@@ -8,16 +8,20 @@ import IIngredient from '../interfaces/IIngredient';
 export class MealwiseDexie extends Dexie {
   recipes!: Table<IRecipe>;
 
+  shoppingDay!: Table;
+
   constructor() {
     super('mealwiseDB');
     this.version(1).stores({
-      recipes: 'id, name, category, description',
+      recipes: 'id, name, category',
+      shoppingDay: 'id, day',
     });
   }
 }
 
 export const db = new MealwiseDexie();
 
+// recipes
 export const addRecipe = async (formData: IFormData, ingredientsList: IIngredient[]) => {
   try {
     const newRecipe = {
@@ -57,4 +61,27 @@ export const getRecipeById = async (id: string) => {
     .toArray();
 
   return recipe[0];
+};
+
+// shoppingDay
+export const addShoppingDay = async (day: string) => {
+  const previousDay = db.shoppingDay
+    .where('id')
+    .equals(1);
+
+  if (previousDay) await db.shoppingDay.delete(1);
+
+  await db.shoppingDay
+    .add({ id: 1, day });
+};
+
+export const getShoppingDay = async () => {
+  const chosenDay = await db.shoppingDay
+    .where('id')
+    .equals(1)
+    .toArray();
+
+  if (!chosenDay[0]) return '';
+
+  return chosenDay[0].day;
 };

--- a/services/dbService.ts
+++ b/services/dbService.ts
@@ -2,19 +2,23 @@ import Dexie, { Table } from 'dexie';
 import { nanoid } from 'nanoid';
 
 import IFormData from '../interfaces/IFormData';
-import IRecipe from '../interfaces/IRecipe';
 import IIngredient from '../interfaces/IIngredient';
+import IMealPlan from '../interfaces/IMealPlan';
+import IRecipe from '../interfaces/IRecipe';
 
 export class MealwiseDexie extends Dexie {
   recipes!: Table<IRecipe>;
 
   shoppingDay!: Table;
 
+  mealPlan!:Table<IMealPlan>;
+
   constructor() {
     super('mealwiseDB');
     this.version(1).stores({
-      recipes: 'id, name, category',
-      shoppingDay: 'id, day',
+      recipes: 'id',
+      shoppingDay: 'id',
+      mealPlan: 'id',
     });
   }
 }
@@ -64,7 +68,7 @@ export const getRecipeById = async (id: string) => {
 };
 
 // shoppingDay
-export const addShoppingDay = async (day: string) => {
+export const selectShoppingDay = async (day: string) => {
   const previousDay = db.shoppingDay
     .where('id')
     .equals(1);
@@ -84,4 +88,28 @@ export const getShoppingDay = async () => {
   if (!chosenDay[0]) return '';
 
   return chosenDay[0].day;
+};
+
+// mealPlan
+export const createMealPlan = async () => {
+  const previousMealPlan = await db.mealPlan
+    .where('id')
+    .equals(1)
+    .toArray();
+
+  if (!previousMealPlan[0]) {
+    await db.mealPlan.add({
+      id: 1,
+      meals: {
+        1: [],
+        2: [],
+        3: [],
+        4: [],
+        5: [],
+        6: [],
+        7: [],
+        8: [],
+      },
+    });
+  }
 };

--- a/services/dbService.ts
+++ b/services/dbService.ts
@@ -101,6 +101,7 @@ export const createMealPlan = async () => {
     await db.mealPlan.add({
       id: 1,
       meals: {
+        0: [],
         1: [],
         2: [],
         3: [],
@@ -108,8 +109,39 @@ export const createMealPlan = async () => {
         5: [],
         6: [],
         7: [],
-        8: [],
       },
     });
   }
+};
+
+export const addMealToPlan = async (dayId: string | string[] | undefined, mealId: string) => {
+  const dayIdAsNum = Number(dayId);
+  const currentMealPlan = await db.mealPlan
+    .where('id')
+    .equals(1)
+    .toArray();
+  const newMealPlan = { ...currentMealPlan[0].meals };
+  const currentDayMeals = newMealPlan[dayIdAsNum];
+  const chosenMeal = await getRecipeById(mealId);
+
+  currentDayMeals.push({
+    id: nanoid(),
+    recipeId: chosenMeal.id,
+  });
+
+  await db.mealPlan.update(1, {
+    id: 1,
+    meals: newMealPlan,
+  });
+};
+
+export const getMeals = async (dayId: string | string[] | undefined) => {
+  const dayIdAsNum = Number(dayId);
+  const mealPlan = await db.mealPlan
+    .where('id')
+    .equals(1)
+    .toArray();
+  const dayMeals = mealPlan[0].meals[dayIdAsNum];
+
+  return dayMeals;
 };


### PR DESCRIPTION
### Description
- Support for saving shopping day to Indexed DB
- Support for saving meal plan to Indexed DB
- Support for saving meals to meal plan

### Spec
See Story: 216, 217, 214, 218

### Validation
* [ ] This PR has code changes, and our linters still pass.
* [ ] This PR affects production code, so it was browser tested.

#### To Validate
  1. Pull down `feat--save-meals-to-planner` branch.
  2. Run `npm install`.
  3. Run `npm run dev`.
  4. Navigate to `localhost:3000/recipes/add` and add a recipe. Then verify recipe renders in `localhost:3000/recipes`.
  5. Navigate to `localhost:3000/planner`, select a shopping day, and add a meal to a day. Then verify the meal renders once you are redirected.
